### PR TITLE
Remove the print of "default"

### DIFF
--- a/beeprint/terminal_size.py
+++ b/beeprint/terminal_size.py
@@ -30,7 +30,6 @@ def get_terminal_size():
     if current_os in ['Linux', 'Darwin'] or current_os.startswith('CYGWIN'):
         tuple_xy = _get_terminal_size_linux()
     if tuple_xy is None:
-        print("default")
         tuple_xy = (80, 25)      # default value
     return tuple_xy
  


### PR DESCRIPTION
Remove the print of "default" when get_terminal_size reverts to default. 

I'm really enjoying this library but this print statement makes it unusable if the program is ever run from JetBeans IntelliJ or PyCharm (and I'm assuming other non-shell environments).  
I have tested this change and it fixes the problem I describe below.

Running this code (before my patch to beeprint): 

    beeprint.pp({value: "just_a_string" for value in range(5)})

I get: 

    {
      0:default
     'just_a_string',
      1:default
     'just_a_string',
      2:default
     'just_a_string',
      3:default
     'just_a_string',
      4:default
     'just_a_string',
    }

Whereas if I run the same line from inside an interpreter in a normal shell I get the expected and desired: 

    {
      0: 'just_a_string',
      1: 'just_a_string',
      2: 'just_a_string',
      3: 'just_a_string',
      4: 'just_a_string',
    }

Thank you so much for beeprint, it's a really nice alternative to IPython pretty and pprint when printing out deeply nested objects. 