### PR TITLE
Fix UnicodeDecodeError

### DIFF
--- a/beeprint/helpers/string.py
+++ b/beeprint/helpers/string.py
@@ -132,7 +132,7 @@ def break_string(s, width):
     if pyv == 3:
         # seg is the type of <class 'bytes'> in py3
         # seg is the type of <type 'str'> in py2
-        seg_list = [seg.decode('utf8') for seg in seg_list]
+        seg_list = [seg.decode('utf8', 'backslashreplace') for seg in seg_list]
     return seg_list
 
 


### PR DESCRIPTION
Fix by wagnerscastle: panyanyany/beeprint/issues/30

Fork with the fix here: [DeleteMetaInf/beeprint](https://github.com/DeleteMetaInf/beeprint)

I tested it, and it works. beeprint no longer causes a UnicodeDecodeError when trying to print a malformed Unicode string or a JSON stringified Python dict. Example:
`'{"image_url": "https://upload.wikimedia.org/wikipedia/commons/8/8d/Sam_Altman_CropEdit_James_Tamim.jpg", "image_title": "Sam Altman - Wikipedia"}'`