### PR TITLE
Fix issue #29

### DIFF
--- a/beeprint/helpers/string.py
+++ b/beeprint/helpers/string.py
@@ -16,7 +16,7 @@ from beeprint.terminal_size import get_terminal_size
 def calc_width(s):
     if hasattr(urwid, 'util'):
         return urwid.util.calc_width(s, 0, len(s))
-    return urwid.str_util.calc_width(s, 0, len(s))
+    return urwid.old_str_util.calc_width(s, 0, len(s))
 
 
 def cut_string(s, length):


### PR DESCRIPTION
Fixing the `AttributeError: module 'urwid' has no attribute 'str_util'` bug.

`str_util` got renamed to `old_str_util`.